### PR TITLE
last pull request was bad. this fixes them.

### DIFF
--- a/src/lib/ReactTitaniumBridge.js
+++ b/src/lib/ReactTitaniumBridge.js
@@ -126,13 +126,15 @@ register("switch", "Titanium.UI.Switch", {
     return Titanium.UI.createSwitch(props);
   }
 });
+/* this is too naive
+we must also support options, option, and buttonNames
 
 register("optiondialog", "Titanium.UI.OptionDialog", {
   factory: function factory(props) {
     return Titanium.UI.createOptionDialog(props);
   }
 });
-
+*/
 register("slider", "Titanium.UI.Slider", {
  factory: function factory(props) {
     return Titanium.UI.createSlider(props);

--- a/src/lib/ReactTitaniumBridge.js
+++ b/src/lib/ReactTitaniumBridge.js
@@ -122,15 +122,21 @@ register("list", "Titanium.UI.ListView", {
 });
 
 register("switch", "Titanium.UI.Switch", {
-  factory: props => Titanium.UI.createSwitch(props)
+  factory: function factory(props) {
+    return Titanium.UI.createSwitch(props);
+  }
 });
 
 register("optiondialog", "Titanium.UI.OptionDialog", {
-  factory: props => Titanium.UI.OptionDialog(props)
+  factory: function factory(props) {
+    return Titanium.UI.createOptionDialog(props);
+  }
 });
 
 register("slider", "Titanium.UI.Slider", {
-  factory: props => 	Titanium.UI.Slider(props)
+ factory: function factory(props) {
+    return Titanium.UI.createSlider(props);
+  }
 });
 
 register("root", "react.titanium.Root", {

--- a/src/lib/ReactTitaniumBridge.js
+++ b/src/lib/ReactTitaniumBridge.js
@@ -141,6 +141,20 @@ register("slider", "Titanium.UI.Slider", {
   }
 });
 
+register("emaildialog", "Ti.UI.createEmailDialog", {
+ factory: function factory(props) {
+    return Ti.UI.createEmailDialog(props);
+  }
+});
+
+register("imageview", "Ti.UI.createImageView", {
+ factory: function factory(props) {
+    return Ti.UI.createEmailDialog(props);
+  }
+});
+
+
+
 register("root", "react.titanium.Root", {
   factory: props => ({
     apiName: "react.titanium.Root",

--- a/src/lib/ReactTitaniumBridge.js
+++ b/src/lib/ReactTitaniumBridge.js
@@ -141,11 +141,7 @@ register("slider", "Titanium.UI.Slider", {
   }
 });
 
-register("emaildialog", "Ti.UI.createEmailDialog", {
- factory: function factory(props) {
-    return Ti.UI.createEmailDialog(props);
-  }
-});
+
 
 register("imageview", "Ti.UI.createImageView", {
  factory: function factory(props) {


### PR DESCRIPTION
I did not mean to send a bad pull request last time.
I also disabled the optionsDialog factory because it needs to support `<Options>` `<Option>` and `<ButtonNames>`

here is a test to prove I got it right this time:

```
import React, { Component } from 'react';
import { render } from 'react-titanium';

class App extends Component {
  state = { counter: 0 };

  increment = () => this.setState({
    counter: this.state.counter + 1
  });

  open = window => {
    if (this.opened || !window) return;

    this.opened = true;
    window.open();
  }

  render() {
    return (
      <window
        onClick={ this.increment }
        ref={ this.open }
      >
        <label color="#09f" text={ this.state.counter } />
        <slider top="100"/>
        <switch top="150" />

      </window>
    );
  }
}

render(<App />);
```
